### PR TITLE
Add dxva2 hw decoder

### DIFF
--- a/src/QtAVPlayer/qavdemuxer.cpp
+++ b/src/QtAVPlayer/qavdemuxer.cpp
@@ -34,6 +34,7 @@
 
 #if defined(Q_OS_WIN)
 #include "qavhwdevice_d3d11_p.h"
+#include "qavhwdevice_dxva2_p.h"
 #endif
 
 #if defined(Q_OS_ANDROID)
@@ -142,9 +143,12 @@ static void setup_video_codec(AVStream *stream, QAVCodec *base)
     if (name == QLatin1String("cocoa") || name == QLatin1String("ios"))
         device.reset(new QAVHWDevice_VideoToolbox);
 #endif
-#if defined(Q_OS_WIN)
+#if defined(Q_OS_WIN) && defined(QT_AVPLAYER_USE_D3D11)
     if (name == QLatin1String("windows"))
         device.reset(new QAVHWDevice_D3D11);
+#elif defined(Q_OS_WIN)
+    if (name == QLatin1String("windows"))
+        device.reset(new QAVHWDevice_DXVA2);
 #endif
 #if defined(Q_OS_ANDROID)
     if (name == QLatin1String("android")) {

--- a/src/QtAVPlayer/qavhwdevice_dxva2.cpp
+++ b/src/QtAVPlayer/qavhwdevice_dxva2.cpp
@@ -1,0 +1,26 @@
+#include "qavhwdevice_dxva2_p.h"
+#include "qavvideobuffer_gpu_p.h"
+
+QT_BEGIN_NAMESPACE
+
+QAVHWDevice_DXVA2::QAVHWDevice_DXVA2(QObject *parent)
+    : QObject(parent)
+{
+}
+
+AVPixelFormat QAVHWDevice_DXVA2::format() const
+{
+    return AV_PIX_FMT_DXVA2_VLD;
+}
+
+AVHWDeviceType QAVHWDevice_DXVA2::type() const
+{
+    return AV_HWDEVICE_TYPE_DXVA2;
+}
+
+QAVVideoBuffer *QAVHWDevice_DXVA2::videoBuffer(const QAVVideoFrame &frame) const
+{
+    return new QAVVideoBuffer_GPU(frame);
+}
+
+QT_END_NAMESPACE

--- a/src/QtAVPlayer/qavhwdevice_dxva2_p.h
+++ b/src/QtAVPlayer/qavhwdevice_dxva2_p.h
@@ -1,0 +1,35 @@
+#ifndef QAVHWDEVICE_DXVA2_P_H
+#define QAVHWDEVICE_DXVA2_P_H
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the Qt API. It exists purely as an
+// implementation detail. This header file may change from version to
+// version without notice, or even be removed.
+//
+// We mean it.
+//
+
+#include "qavhwdevice_p.h"
+
+QT_BEGIN_NAMESPACE
+
+class Q_AVPLAYER_EXPORT QAVHWDevice_DXVA2 : public QObject, public QAVHWDevice
+{
+public:
+    QAVHWDevice_DXVA2(QObject *parent = nullptr);
+    ~QAVHWDevice_DXVA2() = default;
+
+    AVPixelFormat format() const override;
+    AVHWDeviceType type() const override;
+    QAVVideoBuffer *videoBuffer(const QAVVideoFrame &frame) const override;
+
+private:
+    Q_DISABLE_COPY(QAVHWDevice_D3D11)
+};
+
+QT_END_NAMESPACE
+
+#endif

--- a/src/QtAVPlayer/qavhwdevice_dxva2_p.h
+++ b/src/QtAVPlayer/qavhwdevice_dxva2_p.h
@@ -27,7 +27,7 @@ public:
     QAVVideoBuffer *videoBuffer(const QAVVideoFrame &frame) const override;
 
 private:
-    Q_DISABLE_COPY(QAVHWDevice_D3D11)
+    Q_DISABLE_COPY(QAVHWDevice_DXVA2)
 };
 
 QT_END_NAMESPACE


### PR DESCRIPTION
Added dxva2 hw decoder and set it to be the default on windows. Still can use d3d11 but now need to compile with `/DQT_AVPLAYER_USE_D3D11` on windows.