### PR TITLE
Fix mem leak

### DIFF
--- a/src/QtAVPlayer/qavinoutfilter_p_p.h
+++ b/src/QtAVPlayer/qavinoutfilter_p_p.h
@@ -27,7 +27,7 @@ class QAVInOutFilterPrivate
 {
 public:
     QAVInOutFilterPrivate(QAVInOutFilter *q) : q_ptr(q) { }
-    virtual ~QAVInOutFilter() = default;
+    virtual ~QAVInOutFilterPrivate() = default;
 
     QAVInOutFilter *q_ptr = nullptr;
     AVFilterContext *ctx = nullptr;

--- a/src/QtAVPlayer/qavinoutfilter_p_p.h
+++ b/src/QtAVPlayer/qavinoutfilter_p_p.h
@@ -27,6 +27,7 @@ class QAVInOutFilterPrivate
 {
 public:
     QAVInOutFilterPrivate(QAVInOutFilter *q) : q_ptr(q) { }
+    virtual ~QAVInOutFilter() = default;
 
     QAVInOutFilter *q_ptr = nullptr;
     AVFilterContext *ctx = nullptr;


### PR DESCRIPTION
Dtor wasn't marked virtual for a base class. Deleting child classes will leak memory. Should probably contribute back this change.